### PR TITLE
open returns -1 on failure

### DIFF
--- a/main.c
+++ b/main.c
@@ -38,7 +38,7 @@ int process() {
 
 
     fbfd = open("/dev/fb1", O_RDWR);
-    if (!fbfd) {
+    if (fbfd == -1) {
         syslog(LOG_ERR, "Unable to open secondary display");
         return -1;
     }


### PR DESCRIPTION
Hi, spotted a bug. If a call to open() fails it returns -1. You code checks to see if open() returns zero.
